### PR TITLE
fix SinglyLinkedList/removeFirst

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/ir/ac/vru/list/SinglyLinkedList.java
+++ b/src/ir/ac/vru/list/SinglyLinkedList.java
@@ -47,7 +47,7 @@ public class SinglyLinkedList {
         else {
             SingleNode<?> node = this.first;
             this.first = node.getNext();
-            this.first.setNext(null);
+            node.setNext(null);
         }
         this.size--;
     }


### PR DESCRIPTION
There was a bug in `removeFirst` function:
 use `node.setNext(null)` instead of `this.first.setNext(null)`